### PR TITLE
path fixing

### DIFF
--- a/root/assets/css/index.css
+++ b/root/assets/css/index.css
@@ -1,1 +1,1 @@
-@import '_global'
+@import 'global'

--- a/root/views/layout.jade
+++ b/root/views/layout.jade
@@ -14,4 +14,4 @@ html
   body
     block content
 
-    script(src='/js/bundle.js')
+    script(src='/js/main.js')


### PR DESCRIPTION
- apparently when you do a css import it already prepends the `_` so it was looking for `__global.css` 
- js was being bundled in `/js/main.js` and not `/js/bundle.js`

also, it looks like the watcher does not reload when there's a change to the imported `_global.css` file – thats something we'll need to look into