### PR TITLE
add support for cssnext. remove precss

### DIFF
--- a/root/app.js
+++ b/root/app.js
@@ -1,9 +1,10 @@
-import autoprefixer from 'autoprefixer'
-import precss from 'precss'
+import cssnext from 'postcss-cssnext'
 import rucksack from 'rucksack-css'
 
 export default {
-  postCssPlugins: [autoprefixer, precss, rucksack],
+  postcss: {
+    plugins: [cssnext, rucksack]
+  },
   babelConfig: { presets: ['es2015', 'stage-2'] },
   locals: { foo: 'bar' },
   ignore: ['**/layout.jade', '**/_*']

--- a/root/package.json
+++ b/root/package.json
@@ -2,10 +2,10 @@
   "name": "<%= S(name).dasherize().value() %>",
   "description": "<%= description %>",
   "dependencies": {
-    "autoprefixer": "6.x",
     "babel-preset-es2015": "6.x",
     "babel-preset-stage-2": "6.x",
-    "precss": "1.x",
+    "postcss": "^5.0.19",
+    "postcss-cssnext": "^2.5.1",
     "rucksack-css": "0.8.x"
   }
 }


### PR DESCRIPTION
- updates postcss plugin syntax for [roots-mini v3](https://github.com/carrot/roots-mini/releases/tag/v0.0.3)
- removes precss. replaces it with cssnext
- removes autoprefixer, bc thats handled by cssnext now