### PR TITLE
remove roots-mini as a dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "babel-core": "^6.7.2",
     "os-tmpdir": "^1.0.1",
     "rimraf-promise": "^2.0.0",
-    "roots-mini": "0.0.15",
+    "roots-mini": "0.0.x",
     "sprout": "1.x",
     "when": "^3.7.7"
   },

--- a/root/package.json
+++ b/root/package.json
@@ -15,7 +15,6 @@
     "babel-preset-stage-2": "6.x",
     "lost": "6.x",
     "postcss-cssnext": "2.5.x",
-    "roots-mini": "0.0.x",
     "rucksack-css": "0.8.x",
     "sugarss": "0.1.x"
   },


### PR DESCRIPTION
bc it's slow and really only need for netlify. we can manually add it in netlify cases, until we expand this to have a `netlify` prompt 